### PR TITLE
Compile on older versions of Qt, added gitignore to allow forking and easier code sharing across OSs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# QT stuff
+*.pro.user
+
+# Docs
+/docs/_build
+/docs/_build/*
+/docs/_templates
+/docs/_templates/*
+
+# Misc 
+make.bat
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@
 # Misc 
 make.bat
 Makefile
+
+#External
+/external

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -249,9 +249,9 @@ void MainWindow::doDeletion()
         return;
     }
 
-    if (dataTable->selectionModel()->isRowSelected(indexes[0].row())) {
+    if (dataTable->selectionModel()->isRowSelected(indexes[0].row(), QModelIndex())) {
         deleteTaxa();
-    } else if (dataTable->selectionModel()->isColumnSelected(indexes[0].column())) {
+    } else if (dataTable->selectionModel()->isColumnSelected(indexes[0].column(), QModelIndex())) {
         deleteCharacters();
     }
 }


### PR DESCRIPTION
This includes:
-- A change to MainWindow to allow the software to compile on Linux distros which typically have older versions of Qt by default
-- A gitignore which tells git to ignore the contents of the external folder, so this is not synched, and also the .pro.user file which differs between systems